### PR TITLE
rebase to MMTk-0.1

### DIFF
--- a/.github/scripts/get-v8.sh
+++ b/.github/scripts/get-v8.sh
@@ -2,7 +2,10 @@ set -xe
 
 # clean-up the previously created V8 directories
 cd $V8_ROOT
+rm -rf v8
 rm -rf depot_tools
+rm -f .gclient
+rm -f .gclient_entries
 
 # clone the V8/Chromium depot tools and add them to path
 git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
@@ -11,5 +14,5 @@ export PATH=$V8_ROOT/depot_tools:$PATH
 
 # fetch v8 and update dependencies
 gclient
-rm -rf v8
 fetch v8
+gclient sync

--- a/.github/scripts/get-v8.sh
+++ b/.github/scripts/get-v8.sh
@@ -2,7 +2,6 @@ set -xe
 
 # clean-up the previously created V8 directories
 cd $V8_ROOT
-rm -rf v8
 rm -rf depot_tools
 
 # clone the V8/Chromium depot tools and add them to path
@@ -12,5 +11,5 @@ export PATH=$V8_ROOT/depot_tools:$PATH
 
 # fetch v8 and update dependencies
 gclient
+rm -rf v8
 fetch v8
-gclient sync

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: V8 Tests
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     branches:
       - master
 

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -15,7 +15,7 @@ lto = true
 libc = "0.2"
 lazy_static = "1.1"
 log = "*"
-mmtk = { git = "ssh://git@github.com/mmtk/mmtk-core.git", rev = "d82284eaf2ae5e443eb10c236e24f616719bd831" }
+mmtk = { git = "ssh://git@github.com/mmtk/mmtk-core.git", rev = "0615b01837323221bf1d897c5c88bd25a80e3904" }
 
 # Uncomment the following and fix the path to mmtk-core to build locally
 # mmtk = { path = "../../mmtk-core" }

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -15,7 +15,7 @@ lto = true
 libc = "0.2"
 lazy_static = "1.1"
 log = "*"
-mmtk = { git = "ssh://git@github.com/mmtk/mmtk-core.git", rev = "0615b01837323221bf1d897c5c88bd25a80e3904" }
+mmtk = { git = "ssh://git@github.com/mmtk/mmtk-core.git", rev = "5cd2407424061db66cdb8573fac30704b948a11c" }
 
 # Uncomment the following and fix the path to mmtk-core to build locally
 # mmtk = { path = "../../mmtk-core" }

--- a/mmtk/src/active_plan.rs
+++ b/mmtk/src/active_plan.rs
@@ -1,5 +1,6 @@
 use libc::c_void;
 use mmtk::{Plan, SelectedPlan};
+use mmtk::scheduler::GCWorker;
 use mmtk::vm::ActivePlan;
 use mmtk::util::OpaquePointer;
 use V8;
@@ -14,8 +15,8 @@ impl ActivePlan<V8> for VMActivePlan {
         &SINGLETON.plan
     }
 
-    unsafe fn collector(tls: OpaquePointer) -> &'static mut <SelectedPlan<V8> as Plan<V8>>::CollectorT {
-        let c = ((*UPCALLS).active_collector)(tls);
+    fn worker(tls: OpaquePointer) -> &'static mut GCWorker<V8> {
+        let c = unsafe { ((*UPCALLS).active_collector)(tls) };
         assert!(!c.is_null());
         unsafe { &mut *c }
     }
@@ -24,7 +25,7 @@ impl ActivePlan<V8> for VMActivePlan {
         ((*UPCALLS).is_mutator)(tls)
     }
 
-    unsafe fn mutator(tls: OpaquePointer) -> &'static mut <SelectedPlan<V8> as Plan<V8>>::MutatorT {
+    unsafe fn mutator(tls: OpaquePointer) -> &'static mut <SelectedPlan<V8> as Plan>::Mutator {
         let m = ((*UPCALLS).get_mmtk_mutator)(tls);
         unsafe { &mut *m }
     }
@@ -39,7 +40,7 @@ impl ActivePlan<V8> for VMActivePlan {
         }
     }
 
-    fn get_next_mutator() -> Option<&'static mut <SelectedPlan<V8> as Plan<V8>>::MutatorT> {
+    fn get_next_mutator() -> Option<&'static mut <SelectedPlan<V8> as Plan>::Mutator> {
         let _guard = MUTATOR_ITERATOR_LOCK.lock().unwrap();
         unsafe {
             let m = ((*UPCALLS).get_next_mutator)();
@@ -49,6 +50,10 @@ impl ActivePlan<V8> for VMActivePlan {
                 Some(&mut *m)
             }
         }
+    }
+
+    fn number_of_mutators() -> usize {
+        unimplemented!()
     }
 }
 

--- a/mmtk/src/active_plan.rs
+++ b/mmtk/src/active_plan.rs
@@ -1,4 +1,3 @@
-use libc::c_void;
 use mmtk::{Plan, SelectedPlan};
 use mmtk::scheduler::GCWorker;
 use mmtk::vm::ActivePlan;
@@ -27,7 +26,7 @@ impl ActivePlan<V8> for VMActivePlan {
 
     unsafe fn mutator(tls: OpaquePointer) -> &'static mut <SelectedPlan<V8> as Plan>::Mutator {
         let m = ((*UPCALLS).get_mmtk_mutator)(tls);
-        unsafe { &mut *m }
+        &mut *m
     }
 
     fn collector_count() -> usize {

--- a/mmtk/src/api.rs
+++ b/mmtk/src/api.rs
@@ -1,12 +1,9 @@
 use libc::c_void;
 use libc::c_char;
 use std::ffi::CStr;
-use std::ptr::null_mut;
 use mmtk::memory_manager;
 use mmtk::AllocationSemantics;
 use mmtk::util::{ObjectReference, OpaquePointer, Address};
-use mmtk::Plan;
-use mmtk::util::constants::LOG_BYTES_IN_PAGE;
 use mmtk::{Mutator, SelectedPlan};
 use mmtk::scheduler::GCWorker;
 use mmtk::MMTK;

--- a/mmtk/src/api.rs
+++ b/mmtk/src/api.rs
@@ -3,7 +3,7 @@ use libc::c_char;
 use std::ffi::CStr;
 use std::ptr::null_mut;
 use mmtk::memory_manager;
-use mmtk::Allocator;
+use mmtk::AllocationSemantics;
 use mmtk::util::{ObjectReference, OpaquePointer, Address};
 use mmtk::Plan;
 use mmtk::util::constants::LOG_BYTES_IN_PAGE;
@@ -43,14 +43,14 @@ pub extern "C" fn destroy_mutator(mutator: *mut SelectedMutator<V8>) {
 
 #[no_mangle]
 pub extern "C" fn alloc(mutator: &mut SelectedMutator<V8>, size: usize,
-                    align: usize, offset: isize, allocator: Allocator) -> Address {
-    memory_manager::alloc::<V8>(mutator, size, align, offset, allocator)
+                    align: usize, offset: isize, semantics: AllocationSemantics) -> Address {
+    memory_manager::alloc::<V8>(mutator, size, align, offset, semantics)
 }
 
 #[no_mangle]
 pub extern "C" fn post_alloc(mutator: &mut SelectedMutator<V8>, refer: ObjectReference, type_refer: ObjectReference,
-                                        bytes: usize, allocator: Allocator) {
-    memory_manager::post_alloc::<V8>(mutator, refer, type_refer, bytes, allocator)
+                                        bytes: usize, semantics: AllocationSemantics) {
+    memory_manager::post_alloc::<V8>(mutator, refer, type_refer, bytes, semantics)
 }
 
 #[no_mangle]

--- a/mmtk/src/collection.rs
+++ b/mmtk/src/collection.rs
@@ -1,4 +1,3 @@
-use libc::c_void;
 use mmtk::vm::Collection;
 use mmtk::util::OpaquePointer;
 use mmtk::{MutatorContext};
@@ -23,7 +22,7 @@ impl Collection<V8> for VMCollection {
         }
     }
 
-    fn block_for_gc(tls: OpaquePointer) {
+    fn block_for_gc(_tls: OpaquePointer) {
         unsafe {
             ((*UPCALLS).block_for_gc)();
         }
@@ -41,6 +40,6 @@ impl Collection<V8> for VMCollection {
     }
 
     fn prepare_mutator<T: MutatorContext<V8>>(tls: OpaquePointer, m: &T) {
-        // unimplemented!()
+        unimplemented!()
     }
 }

--- a/mmtk/src/object_archive.rs
+++ b/mmtk/src/object_archive.rs
@@ -1,4 +1,3 @@
-use std::slice::Iter;
 use std::sync::RwLock;
 use libc::c_void;
 use mmtk::util::address::Address;
@@ -39,7 +38,7 @@ pub extern "C" fn tph_archive_inner_to_obj(
     let arch = 
         unsafe { Box::from_raw(arch as *mut ObjectArchive) };
     let res = arch.inner_addr_to_object(Address::from_mut_ptr(inner_ptr));
-    let arch = Box::into_raw(arch);
+    Box::into_raw(arch);
     res.to_mut_ptr()
 }
 
@@ -49,7 +48,7 @@ pub extern "C" fn tph_archive_obj_to_isolate(
     let arch = 
         unsafe { Box::from_raw(arch as *mut ObjectArchive) };
     let res = arch.object_to_isolate(Address::from_mut_ptr(obj_ptr));
-    let arch = Box::into_raw(arch);
+    Box::into_raw(arch);
     res.to_mut_ptr()
 }
 
@@ -59,7 +58,7 @@ pub extern "C" fn tph_archive_obj_to_space(
     let arch = 
         unsafe { Box::from_raw(arch as *mut ObjectArchive) };
     let res = arch.object_to_space(Address::from_mut_ptr(obj_ptr));
-    let arch = Box::into_raw(arch);
+    Box::into_raw(arch);
     res
 }
 
@@ -156,7 +155,7 @@ impl ObjectArchive {
         let idx = 
             match lst.binary_search(&obj_addr.as_usize()) {
                 Ok(idx) => idx,
-                Err(idx) => {
+                Err(_) => {
                     panic!("OA.remove: Object {:?} not archived!", obj_addr);
                 }
             };

--- a/mmtk/src/object_model.rs
+++ b/mmtk/src/object_model.rs
@@ -1,10 +1,8 @@
-use libc::c_void;
 use mmtk::vm::*;
 use mmtk::AllocationSemantics;
 use mmtk::CopyContext;
 use mmtk::util::{Address, ObjectReference};
-use mmtk::util::OpaquePointer;
-use std::sync::atomic::{AtomicU8, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU8};
 use super::UPCALLS;
 use V8;
 

--- a/mmtk/src/object_model.rs
+++ b/mmtk/src/object_model.rs
@@ -1,6 +1,6 @@
 use libc::c_void;
 use mmtk::vm::*;
-use mmtk::Allocator;
+use mmtk::AllocationSemantics;
 use mmtk::util::{Address, ObjectReference};
 use mmtk::util::OpaquePointer;
 use std::sync::atomic::{AtomicU8, AtomicUsize, Ordering};
@@ -19,7 +19,7 @@ impl ObjectModel<V8> for VMObjectModel {
        unimplemented!()
     }
 
-    fn copy(from: ObjectReference, allocator: Allocator, tls: OpaquePointer) -> ObjectReference {
+    fn copy(from: ObjectReference, semantics: AllocationSemantics, tls: OpaquePointer) -> ObjectReference {
         unimplemented!()
     }
 

--- a/mmtk/src/object_model.rs
+++ b/mmtk/src/object_model.rs
@@ -1,12 +1,12 @@
 use libc::c_void;
 use mmtk::vm::*;
 use mmtk::AllocationSemantics;
+use mmtk::CopyContext;
 use mmtk::util::{Address, ObjectReference};
 use mmtk::util::OpaquePointer;
 use std::sync::atomic::{AtomicU8, AtomicUsize, Ordering};
 use super::UPCALLS;
 use V8;
-use mmtk::CollectorContext;
 
 pub struct VMObjectModel {}
 
@@ -19,7 +19,7 @@ impl ObjectModel<V8> for VMObjectModel {
        unimplemented!()
     }
 
-    fn copy(from: ObjectReference, semantics: AllocationSemantics, tls: OpaquePointer) -> ObjectReference {
+    fn copy(from: ObjectReference, allocator: AllocationSemantics, copy_context: &mut impl CopyContext) -> ObjectReference {
         unimplemented!()
     }
 

--- a/mmtk/src/reference_glue.rs
+++ b/mmtk/src/reference_glue.rs
@@ -1,4 +1,3 @@
-use libc::c_void;
 use mmtk::vm::ReferenceGlue;
 use mmtk::util::ObjectReference;
 use mmtk::TraceLocal;

--- a/mmtk/src/scanning.rs
+++ b/mmtk/src/scanning.rs
@@ -1,13 +1,9 @@
-use libc::c_void;
 use mmtk::vm::Scanning;
-use mmtk::{Mutator, SelectedPlan, TransitiveClosure, TraceLocal};
-use mmtk::util::{ObjectReference, SynchronizedCounter};
+use mmtk::{Mutator, SelectedPlan, TransitiveClosure};
+use mmtk::util::{ObjectReference};
 use mmtk::util::OpaquePointer;
 use mmtk::scheduler::gc_works::ProcessEdgesWork;
 use V8;
-use super::UPCALLS;
-
-static COUNTER: SynchronizedCounter = SynchronizedCounter::new(0);
 
 pub struct VMScanning {}
 

--- a/mmtk/src/scanning.rs
+++ b/mmtk/src/scanning.rs
@@ -1,8 +1,9 @@
 use libc::c_void;
 use mmtk::vm::Scanning;
-use mmtk::{TransitiveClosure, TraceLocal};
+use mmtk::{Mutator, SelectedPlan, TransitiveClosure, TraceLocal};
 use mmtk::util::{ObjectReference, SynchronizedCounter};
 use mmtk::util::OpaquePointer;
+use mmtk::scheduler::gc_works::ProcessEdgesWork;
 use V8;
 use super::UPCALLS;
 
@@ -11,45 +12,35 @@ static COUNTER: SynchronizedCounter = SynchronizedCounter::new(0);
 pub struct VMScanning {}
 
 impl Scanning<V8> for VMScanning {
+    const SCAN_MUTATORS_IN_SAFEPOINT: bool = false;
+    const SINGLE_THREAD_MUTATOR_SCANNING: bool = false;
+
     fn scan_object<T: TransitiveClosure>(trace: &mut T, object: ObjectReference, tls: OpaquePointer) {
-        unsafe {
-            ((*UPCALLS).scan_object)(::std::mem::transmute(trace), object, tls);
-        }
-    }
-
-    fn reset_thread_counter() {
-        COUNTER.reset();
-    }
-
-    fn notify_initial_thread_scan_complete(partial_scan: bool, tls: OpaquePointer) {
-        // unimplemented!()
-        // TODO
-    }
-
-    fn compute_static_roots<T: TraceLocal>(trace: &mut T, tls: OpaquePointer) {
-        unsafe {
-            ((*UPCALLS).compute_static_roots)(::std::mem::transmute(trace), tls);
-        }
-    }
-
-    fn compute_global_roots<T: TraceLocal>(trace: &mut T, tls: OpaquePointer) {
-        unsafe {
-            ((*UPCALLS).compute_global_roots)(::std::mem::transmute(trace), tls);
-        }
-    }
-
-    fn compute_thread_roots<T: TraceLocal>(trace: &mut T, tls: OpaquePointer) {
-        unsafe {
-            ((*UPCALLS).compute_thread_roots)(::std::mem::transmute(trace), tls);
-        }
-    }
-
-    fn compute_new_thread_roots<T: TraceLocal>(trace: &mut T, tls: OpaquePointer) {
         unimplemented!()
     }
 
-    fn compute_bootimage_roots<T: TraceLocal>(trace: &mut T, tls: OpaquePointer) {
-        // Do nothing
+    fn reset_thread_counter() {
+        unimplemented!()
+    }
+
+    fn notify_initial_thread_scan_complete(_partial_scan: bool, _tls: OpaquePointer) {
+        unimplemented!()
+    }
+
+    fn scan_objects<W: ProcessEdgesWork<VM=V8>>(objects: &[ObjectReference]) {
+        unimplemented!()
+    }
+
+    fn scan_thread_roots<W: ProcessEdgesWork<VM=V8>>() {
+        unimplemented!()
+    }
+
+    fn scan_thread_root<W: ProcessEdgesWork<VM=V8>>(mutator: &'static mut Mutator<SelectedPlan<V8>>, _tls: OpaquePointer) {
+        unimplemented!()
+    }
+
+    fn scan_vm_specific_roots<W: ProcessEdgesWork<VM=V8>>() {
+        unimplemented!()
     }
 
     fn supports_return_barrier() -> bool {

--- a/v8/third_party/heap/mmtk/mmtk.h
+++ b/v8/third_party/heap/mmtk/mmtk.h
@@ -44,23 +44,6 @@ extern bool is_in_code_space(void* addr);
 /**
  * Tracing
  */
-extern void report_delayed_root_edge(void *mmtk,
-                                     MMTk_TraceLocal trace_local,
-                                     void* addr);
-
-extern bool will_not_move_in_current_collection(void *mmtk,
-                                                MMTk_TraceLocal trace_local,
-                                                void* obj);
-
-extern void process_interior_edge(void *mmtk,
-                                  MMTk_TraceLocal trace_local, void* target,
-                                  void* slot, bool root);
-
-extern void* trace_get_forwarded_referent(MMTk_TraceLocal trace_local, void* obj);
-
-extern void* trace_get_forwarded_reference(MMTk_TraceLocal trace_local, void* obj);
-
-extern void* trace_retain_referent(MMTk_TraceLocal trace_local, void* obj);
 
 /**
  * Misc


### PR DESCRIPTION
This PR updates mmtk-v8 to work with MMTk-0.1.
It also includes some unused code clean-up.