### PR TITLE
Add ci-test.sh

### DIFF
--- a/.github/scripts/args.gn
+++ b/.github/scripts/args.gn
@@ -1,6 +1,10 @@
 # Build arguments go here.
 # See "gn args <out_dir> --list" for available build arguments.
 #
+declare_args() {
+    the_root = getenv("THE_ROOT")
+}
+
 is_component_build = true
 is_debug = true
 symbol_level = 2
@@ -16,8 +20,8 @@ v8_enable_single_generation = true
 v8_enable_shared_ro_heap = false
 v8_enable_pointer_compression = false
 v8_enable_third_party_heap = true
-v8_third_party_heap_files = [ "../mmtk-v8/v8/third_party/heap/mmtk/mmtk.cc", 
-"../mmtk-v8/v8/third_party/heap/mmtk/mmtk.h",
-"../mmtk-v8/v8/third_party/heap/mmtk/mmtkUpcalls.h",
-"../mmtk-v8/v8/third_party/heap/mmtk/mmtkUpcalls.cc"]
-v8_third_party_heap_libs = [ "../mmtk-v8/mmtk/target/debug/libmmtk_v8.so" ]
+v8_third_party_heap_files = [ "$the_root/mmtk-v8/v8/third_party/heap/mmtk/mmtk.cc", 
+"$the_root/mmtk-v8/v8/third_party/heap/mmtk/mmtk.h",
+"$the_root/mmtk-v8/v8/third_party/heap/mmtk/mmtkUpcalls.h",
+"$the_root/mmtk-v8/v8/third_party/heap/mmtk/mmtkUpcalls.cc"]
+v8_third_party_heap_libs = [ "$the_root/mmtk-v8/mmtk/target/debug/libmmtk_v8.so" ]

--- a/.github/scripts/args.gn
+++ b/.github/scripts/args.gn
@@ -20,8 +20,8 @@ v8_enable_single_generation = true
 v8_enable_shared_ro_heap = false
 v8_enable_pointer_compression = false
 v8_enable_third_party_heap = true
-v8_third_party_heap_files = [ "$the_root/mmtk-v8/v8/third_party/heap/mmtk/mmtk.cc", 
-"$the_root/mmtk-v8/v8/third_party/heap/mmtk/mmtk.h",
-"$the_root/mmtk-v8/v8/third_party/heap/mmtk/mmtkUpcalls.h",
-"$the_root/mmtk-v8/v8/third_party/heap/mmtk/mmtkUpcalls.cc"]
-v8_third_party_heap_libs = [ "$the_root/mmtk-v8/mmtk/target/debug/libmmtk_v8.so" ]
+v8_third_party_heap_files = [ "$the_root/v8/third_party/heap/mmtk/mmtk.cc", 
+"$the_root/v8/third_party/heap/mmtk/mmtk.h",
+"$the_root/v8/third_party/heap/mmtk/mmtkUpcalls.h",
+"$the_root/v8/third_party/heap/mmtk/mmtkUpcalls.cc"]
+v8_third_party_heap_libs = [ "$the_root/mmtk/target/debug/libmmtk_v8.so" ]

--- a/.github/scripts/build-mmtk.sh
+++ b/.github/scripts/build-mmtk.sh
@@ -1,5 +1,7 @@
 set -xe
 
+. $(dirname "$0")/common.sh
+
 # simply build mmtk-v8 with nogc
-cd $THE_ROOT/mmtk-v8/mmtk
+cd $THE_ROOT/mmtk
 rustup run $RUSTUP_TOOLCHAIN cargo build --features nogc

--- a/.github/scripts/build-v8.sh
+++ b/.github/scripts/build-v8.sh
@@ -1,5 +1,7 @@
 set -xe
 
+. $(dirname "$0")/common.sh
+
 # change to the V8 directory
 cd $V8_ROOT/v8
 
@@ -9,7 +11,7 @@ export PATH=$V8_ROOT/depot_tools:$PATH
 # generate the default setup and copy mmtk-v8's required arguments
 mkdir -p out/x64.debug-mmtk
 # copy the args
-cp $THE_ROOT/mmtk-v8/.github/scripts/args.gn out/x64.debug-mmtk/
+cp $THE_ROOT/.github/scripts/args.gn out/x64.debug-mmtk/
 # generate files according to the copied args file
 gn gen out/x64.debug-mmtk
 # build our V8 setup, named debug-mmtk

--- a/.github/scripts/build-v8.sh
+++ b/.github/scripts/build-v8.sh
@@ -7,7 +7,7 @@ cd $V8_ROOT/v8
 export PATH=$V8_ROOT/depot_tools:$PATH
 
 # generate the default setup and copy mmtk-v8's required arguments
-mkdir out/x64.debug-mmtk
+mkdir -p out/x64.debug-mmtk
 # copy the args
 cp $THE_ROOT/mmtk-v8/.github/scripts/args.gn out/x64.debug-mmtk/
 # generate files according to the copied args file

--- a/.github/scripts/ci-test.sh
+++ b/.github/scripts/ci-test.sh
@@ -4,7 +4,6 @@ set -xe
 
 CUR=$(dirname "$0")
 
-$CUR/ci-setup.sh
 $CUR/build-mmtk.sh
 $CUR/get-v8.sh
 $CUR/build-v8.sh

--- a/.github/scripts/ci-test.sh
+++ b/.github/scripts/ci-test.sh
@@ -1,5 +1,7 @@
 set -xe
 
+. $(dirname "$0")/common.sh
+
 CUR=$(dirname "$0")
 
 $CUR/ci-setup.sh

--- a/.github/scripts/ci-test.sh
+++ b/.github/scripts/ci-test.sh
@@ -1,0 +1,11 @@
+set -xe
+
+CUR=$(dirname "$0")
+
+$CUR/ci-setup.sh
+$CUR/build-mmtk.sh
+$CUR/get-v8.sh
+$CUR/build-v8.sh
+# $CUR/run-regress.sh
+# $CUR/run-unittests.sh
+$CUR/run-benchmarks.sh

--- a/.github/scripts/common.sh
+++ b/.github/scripts/common.sh
@@ -1,4 +1,7 @@
 set -ex
 
+# The root for the mmtk-v8 repo
 export THE_ROOT=`realpath $(dirname "$0")/../..`
+
+# Test with a specific revision.
 export V8_VERSION=dd80f2e4cf4fd254c389d6fee58dc8d44d84fed0

--- a/.github/scripts/common.sh
+++ b/.github/scripts/common.sh
@@ -1,3 +1,4 @@
 set -ex
 
 export THE_ROOT=`realpath $(dirname "$0")/../..`
+export V8_VERSION=dd80f2e4cf4fd254c389d6fee58dc8d44d84fed0

--- a/.github/scripts/common.sh
+++ b/.github/scripts/common.sh
@@ -1,0 +1,3 @@
+set -ex
+
+export THE_ROOT=`realpath $(dirname "$0")/../..`

--- a/.github/scripts/get-v8.sh
+++ b/.github/scripts/get-v8.sh
@@ -3,6 +3,7 @@ set -xe
 . $(dirname "$0")/common.sh
 
 # clean-up the previously created V8 directories
+mkdir -p $V8_ROOT
 cd $V8_ROOT
 rm -rf v8
 rm -rf depot_tools

--- a/.github/scripts/get-v8.sh
+++ b/.github/scripts/get-v8.sh
@@ -18,9 +18,8 @@ export PATH=$V8_ROOT/depot_tools:$PATH
 # fetch v8 and update dependencies
 gclient
 fetch v8
-gclient sync
-
 # Test with a specific revision.
 # TODO: We should have a better way of specifying version.
-cd v8
-git checkout dd80f2e4cf4fd254c389d6fee58dc8d44d84fed0
+git checkout -C v8 $V8_VERSION
+
+gclient sync

--- a/.github/scripts/get-v8.sh
+++ b/.github/scripts/get-v8.sh
@@ -18,8 +18,6 @@ export PATH=$V8_ROOT/depot_tools:$PATH
 # fetch v8 and update dependencies
 gclient
 fetch v8
-# Test with a specific revision.
-# TODO: We should have a better way of specifying version.
 git -C v8 checkout $V8_VERSION
 
 gclient sync

--- a/.github/scripts/get-v8.sh
+++ b/.github/scripts/get-v8.sh
@@ -20,6 +20,6 @@ gclient
 fetch v8
 # Test with a specific revision.
 # TODO: We should have a better way of specifying version.
-git checkout -C v8 $V8_VERSION
+git -C v8 checkout $V8_VERSION
 
 gclient sync

--- a/.github/scripts/get-v8.sh
+++ b/.github/scripts/get-v8.sh
@@ -1,5 +1,7 @@
 set -xe
 
+. $(dirname "$0")/common.sh
+
 # clean-up the previously created V8 directories
 cd $V8_ROOT
 rm -rf v8

--- a/.github/scripts/get-v8.sh
+++ b/.github/scripts/get-v8.sh
@@ -19,3 +19,8 @@ export PATH=$V8_ROOT/depot_tools:$PATH
 gclient
 fetch v8
 gclient sync
+
+# Test with a specific revision.
+# TODO: We should have a better way of specifying version.
+cd v8
+git checkout dd80f2e4cf4fd254c389d6fee58dc8d44d84fed0

--- a/.github/scripts/run-benchmarks.sh
+++ b/.github/scripts/run-benchmarks.sh
@@ -1,5 +1,7 @@
 set -xe
 
+. $(dirname "$0")/common.sh
+
 # change to the V8 directory
 cd $V8_ROOT/v8
 

--- a/.github/scripts/run-regress.sh
+++ b/.github/scripts/run-regress.sh
@@ -1,5 +1,7 @@
 set -xe
 
+. $(dirname "$0")/common.sh
+
 # change to the V8 directory
 cd $V8_ROOT/v8
 

--- a/.github/scripts/run-unittests.sh
+++ b/.github/scripts/run-unittests.sh
@@ -1,5 +1,7 @@
 set -xe
 
+. $(dirname "$0")/common.sh
+
 # change to the V8 directory
 cd $V8_ROOT/v8
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   RUSTUP_TOOLCHAIN: nightly-2020-07-08
-  THE_ROOT: /home/gitlab-runner/actions-runner/_work/mmtk-v8
   V8_ROOT: /home/gitlab-runner/actions-runner/_work/mmtk-v8
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,16 +21,16 @@ jobs:
       - name: Set credential for cargo dependency
         run: sed -i 's/ssh:\/\/git@github.com\/mmtk/https:\/\/javadamiri:${{ secrets.CI_ACCESS_TOKEN }}@github.com\/mmtk/g' mmtk/Cargo.toml
       
-      - name: Set env
+      - name: Set env vars
         run: |
           echo "RUSTUP_TOOLCHAIN=nightly-2020-07-08" >> $GITHUB_ENV
-          echo "V8_ROOT=$GITHUB_WORKSPACE/repos" >> $GITHUB_ENV
+          echo "V8_ROOT=$GITHUB_WORKSPACE/v8_deps" >> $GITHUB_ENV
+      - name: Setup Environments
+        run: ./.github/scripts/ci-setup.sh
 
       # Be aware that any changes made to the following steps should be made to ci-test.sh as well.
       # MMTk core tests the V8 binding by invoking ci-test.sh.
 
-      - name: Setup Environments
-        run: ./.github/scripts/ci-setup.sh
       
       - name: Build MMTk NOGC
         run: ./.github/scripts/build-mmtk.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set env
         run: |
           echo "RUSTUP_TOOLCHAIN=nightly-2020-07-08" >> $GITHUB_ENV
-          echo "V8_ROOT=$GITHUB_WORKSPACE/v8-deps" >> $GITHUB_ENV
+          echo "V8_ROOT=$GITHUB_WORKSPACE/repos" >> $GITHUB_ENV
 
       # Be aware that any changes made to the following steps should be made to ci-test.sh as well.
       # MMTk core tests the V8 binding by invoking ci-test.sh.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,10 @@ jobs:
       
       - name: Set credential for cargo dependency
         run: sed -i 's/ssh:\/\/git@github.com\/mmtk/https:\/\/javadamiri:${{ secrets.CI_ACCESS_TOKEN }}@github.com\/mmtk/g' mmtk/Cargo.toml
-      
+
+      # Be aware that any changes made to the following steps should be made to ci-test.sh as well.
+      # MMTk core tests the V8 binding by invoking ci-test.sh.
+
       - name: Setup Environments
         run: ./.github/scripts/ci-setup.sh
       

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,6 @@ on:
     branches:
       - master
 
-env:
-  RUSTUP_TOOLCHAIN: nightly-2020-07-08
-  V8_ROOT: $GITHUB_WORKSPACE/v8-deps
-
 jobs:
   test:
     runs-on: [self-hosted, linux, freq-scaling-on]
@@ -24,6 +20,11 @@ jobs:
       
       - name: Set credential for cargo dependency
         run: sed -i 's/ssh:\/\/git@github.com\/mmtk/https:\/\/javadamiri:${{ secrets.CI_ACCESS_TOKEN }}@github.com\/mmtk/g' mmtk/Cargo.toml
+      
+      - name: Set env
+        run: |
+          echo "RUSTUP_TOOLCHAIN=nightly-2020-07-08" >> $GITHUB_ENV
+          echo "V8_ROOT=$GITHUB_WORKSPACE/v8-deps" >> $GITHUB_ENV
 
       # Be aware that any changes made to the following steps should be made to ci-test.sh as well.
       # MMTk core tests the V8 binding by invoking ci-test.sh.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   RUSTUP_TOOLCHAIN: nightly-2020-07-08
-  V8_ROOT: /home/gitlab-runner/actions-runner/_work/mmtk-v8
+  V8_ROOT: $GITHUB_WORKSPACE/v8-deps
 
 jobs:
   test:
@@ -40,6 +40,8 @@ jobs:
       - name: Build V8 with MMTk
         run: ./.github/scripts/build-v8.sh
       
+      # The following two steps are currently failing, so they are not included in ci-test.sh.
+      # Once they pass, we should add them to ci-test.sh      
       - name: Run V8 regression Tests
         run: ./.github/scripts/run-regress.sh
         continue-on-error: true

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -15,10 +15,17 @@ lto = true
 libc = "0.2"
 lazy_static = "1.1"
 log = "*"
-mmtk = { git = "ssh://git@github.com/mmtk/mmtk-core.git", rev = "5cd2407424061db66cdb8573fac30704b948a11c" }
 
+# Be very careful to commit any changes to the following mmtk dependency, as our CI scripts (including mmtk-core CI)
+# rely on matching these lines to modify them: e.g. change ssh to https with token or comment out the git dependency
+# and use the local path.
+# These changes are safe:
+# - change branch
+# - change repo name
+# But other changes including adding/removing whitespaces in commented lines may break the CI.
+mmtk = { git = "ssh://git@github.com/mmtk/mmtk-core.git", rev = "5cd2407424061db66cdb8573fac30704b948a11c" }
 # Uncomment the following and fix the path to mmtk-core to build locally
-# mmtk = { path = "../../mmtk-core" }
+# mmtk = { path = "../repos/mmtk-core" }
 
 [features]
 default = ["code_space", "ro_space", "force_32bit_heap_layout"]


### PR DESCRIPTION
This PR cleans up CI scripts, and adds `ci-test.sh` that will be used for mmtk-core.
* `THE_ROOT` is no longer needed. We can get it from the location of the scripts (assuming scripts are always in `.github/scripts`). `THE_ROOT` now points the root of the `mmtk-v8` repo, rather than its parent.
* `V8_ROOT` now uses a relative path from `$GITHUB_WORKSPACE`.
*  Extract a `common.sh` that is included in each script. 
* Replace the hard coded path in `args.gn` with the env var `THE_ROOT`. 
* Change the mmtk dependency in `Cargo.toml` to be consistent with other binding repos.
* Check out a specific version of v8 for testing.
* Fix scripts for paths that exist or do not exist.