### PR TITLE
Fix object iterator and disable multiple isolates

### DIFF
--- a/mmtk/src/object_archive.rs
+++ b/mmtk/src/object_archive.rs
@@ -241,7 +241,6 @@ impl ObjectArchive {
         if self.iter_pos < lst.len() {
             unsafe { Address::from_usize(lst[self.iter_pos]) }
         } else {
-            self.iter_pos = 0;
             unsafe { Address::zero() }
         }
     }

--- a/v8/third_party/heap/mmtk/mmtk.cc
+++ b/v8/third_party/heap/mmtk/mmtk.cc
@@ -180,23 +180,17 @@ bool Heap::IsValidHeapObject(HeapObject object) {
   return is_live_object(reinterpret_cast<void*>(object.address()));
 }
 
-// Access to the heap object iterator is assumed to be single-threaded.
-static bool iteration_finished = false;
-
 void Heap::ResetIterator() {
   TPHData* tph_data_ = get_tph_data(this);
   tph_archive_iter_reset(tph_data_->archive());
-  iteration_finished = false;
 }
 
 HeapObject Heap::NextObject() {
-  if (iteration_finished) return HeapObject();
   TPHData* tph_data_ = get_tph_data(this);
   void* obj_addr = tph_archive_iter_next(tph_data_->archive());
   if (obj_addr != nullptr) {
     return HeapObject::FromAddress(reinterpret_cast<Address>(obj_addr));
   } else {
-    iteration_finished = true;
     return HeapObject();
   }
 }

--- a/v8/third_party/heap/mmtk/mmtk.cc
+++ b/v8/third_party/heap/mmtk/mmtk.cc
@@ -20,7 +20,7 @@ class TPHData {
     v8::internal::Isolate * isolate() { return isolate_; }
     MMTk_Heap_Archive archive() { return tph_archive_; }
 
-    TPHData(Heap* v8_tph, MMTk_Heap mmtk_heap, Isolate* isolate, MMTk_Heap_Archive tph_archive): 
+    TPHData(Heap* v8_tph, MMTk_Heap mmtk_heap, Isolate* isolate, MMTk_Heap_Archive tph_archive):
       v8_tph_(v8_tph), mmtk_heap_(mmtk_heap), isolate_(isolate), tph_archive_(tph_archive) {}
 };
 
@@ -75,11 +75,15 @@ MMTk_Heap GetMMTkHeap(Address object_pointer) {
   UNREACHABLE();
 }
 
+static std::atomic_bool IsolateCreated { false };
+
 std::unique_ptr<Heap> Heap::New(v8::internal::Isolate* isolate) {
   // MMTK current default maximum heap size is 1GB.
-  printf("New Isolate: %lx\n", (unsigned long) isolate);
+  auto isolate_created = IsolateCreated.exchange(true);
+  DCHECK_WITH_MSG(!isolate_created, "Multiple isolates are not supported.");
+  fprintf(stderr, "New Isolate: %lx\n", (unsigned long) isolate);
   const size_t GB = 1u << 30;
-  MMTk_Heap new_heap = v8_new_heap(&mmtk_upcalls, GB);    
+  MMTk_Heap new_heap = v8_new_heap(&mmtk_upcalls, GB);
   tph_mutator_ = reinterpret_cast<BumpAllocator*>(bind_mutator(new_heap, &tph_mutator_));
   // FIXME
   code_range_ = base::AddressRegion(0x60000000, (0xb0000000- 0x60000000)); // isolate->AddCodeRange(code_range_.begin(), code_range_.size());
@@ -121,7 +125,7 @@ AllocationResult Heap::Allocate(size_t size_in_bytes, AllocationType type, Alloc
 Address Heap::GetObjectFromInnerPointer(Address inner_pointer) {
   TPHData* tph_data_ = get_tph_data(this);
   return reinterpret_cast<Address>(
-      tph_archive_inner_to_obj(tph_data_->archive(), 
+      tph_archive_inner_to_obj(tph_data_->archive(),
                                reinterpret_cast<void*>(inner_pointer)));
 }
 
@@ -176,17 +180,23 @@ bool Heap::IsValidHeapObject(HeapObject object) {
   return is_live_object(reinterpret_cast<void*>(object.address()));
 }
 
+// Access to the heap object iterator is assumed to be single-threaded.
+static bool iteration_finished = false;
+
 void Heap::ResetIterator() {
   TPHData* tph_data_ = get_tph_data(this);
   tph_archive_iter_reset(tph_data_->archive());
+  iteration_finished = false;
 }
 
 HeapObject Heap::NextObject() {
+  if (iteration_finished) return HeapObject();
   TPHData* tph_data_ = get_tph_data(this);
   void* obj_addr = tph_archive_iter_next(tph_data_->archive());
   if (obj_addr != nullptr) {
     return HeapObject::FromAddress(reinterpret_cast<Address>(obj_addr));
   } else {
+    iteration_finished = true;
     return HeapObject();
   }
 }


### PR DESCRIPTION
This PR:

* Make heap object iterator always return null when finished an iteration.
* Disable the creation of a second isolate -- We don't fully support it now.

