### PR TITLE
Update mmtk-core PR #647

### DIFF
--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -340,7 +340,7 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.14.0"
-source = "git+https://github.com/qinsoon/mmtk-core.git?rev=3b6d3657c160fdab12b508a936650fa530253936#3b6d3657c160fdab12b508a936650fa530253936"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=4ae23b1dc0e14f62c196c12c93818e00e9de7cc5#4ae23b1dc0e14f62c196c12c93818e00e9de7cc5"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -364,7 +364,7 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.14.0"
-source = "git+https://github.com/qinsoon/mmtk-core.git?rev=3b6d3657c160fdab12b508a936650fa530253936#3b6d3657c160fdab12b508a936650fa530253936"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=4ae23b1dc0e14f62c196c12c93818e00e9de7cc5#4ae23b1dc0e14f62c196c12c93818e00e9de7cc5"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -340,7 +340,7 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.14.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=76131c493be38e421f5fb157f9900f850584554f#76131c493be38e421f5fb157f9900f850584554f"
+source = "git+https://github.com/qinsoon/mmtk-core.git?rev=3b6d3657c160fdab12b508a936650fa530253936#3b6d3657c160fdab12b508a936650fa530253936"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -354,6 +354,7 @@ dependencies = [
  "libc",
  "log",
  "mmtk-macros",
+ "num-traits",
  "num_cpus",
  "spin",
  "strum",
@@ -363,7 +364,7 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.14.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=76131c493be38e421f5fb157f9900f850584554f#76131c493be38e421f5fb157f9900f850584554f"
+source = "git+https://github.com/qinsoon/mmtk-core.git?rev=3b6d3657c160fdab12b508a936650fa530253936#3b6d3657c160fdab12b508a936650fa530253936"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -379,6 +380,15 @@ dependencies = [
  "libc",
  "log",
  "mmtk",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -27,7 +27,7 @@ log = "*"
 # - change branch
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "76131c493be38e421f5fb157f9900f850584554f" }
+mmtk = { git = "https://github.com/qinsoon/mmtk-core.git", rev = "3b6d3657c160fdab12b508a936650fa530253936" }
 # Uncomment the following and fix the path to mmtk-core to build locally
 # mmtk = { path = "../repos/mmtk-core" }
 

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -27,7 +27,7 @@ log = "*"
 # - change branch
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/qinsoon/mmtk-core.git", rev = "3b6d3657c160fdab12b508a936650fa530253936" }
+mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "4ae23b1dc0e14f62c196c12c93818e00e9de7cc5" }
 # Uncomment the following and fix the path to mmtk-core to build locally
 # mmtk = { path = "../repos/mmtk-core" }
 

--- a/mmtk/src/object_model.rs
+++ b/mmtk/src/object_model.rs
@@ -1,8 +1,5 @@
-use std::sync::atomic::Ordering;
-
 use super::UPCALLS;
 use mmtk::util::copy::*;
-use mmtk::util::metadata::header_metadata::HeaderMetadataSpec;
 use mmtk::util::{Address, ObjectReference};
 use mmtk::vm::*;
 use V8;
@@ -19,55 +16,6 @@ impl ObjectModel<V8> for VMObjectModel {
     const LOCAL_MARK_BIT_SPEC: VMLocalMarkBitSpec = VMLocalMarkBitSpec::in_header(0);
     const LOCAL_LOS_MARK_NURSERY_SPEC: VMLocalLOSMarkNurserySpec =
         VMLocalLOSMarkNurserySpec::in_header(0);
-
-    fn load_metadata(
-        _metadata_spec: &HeaderMetadataSpec,
-        _object: ObjectReference,
-        _mask: Option<usize>,
-        _atomic_ordering: Option<Ordering>,
-    ) -> usize {
-        unimplemented!()
-    }
-
-    fn store_metadata(
-        _metadata_spec: &HeaderMetadataSpec,
-        _object: ObjectReference,
-        _val: usize,
-        _mask: Option<usize>,
-        _atomic_ordering: Option<Ordering>,
-    ) {
-        unimplemented!()
-    }
-
-    fn compare_exchange_metadata(
-        _metadata_spec: &HeaderMetadataSpec,
-        _object: ObjectReference,
-        _old_val: usize,
-        _new_val: usize,
-        _mask: Option<usize>,
-        _success_order: Ordering,
-        _failure_order: Ordering,
-    ) -> bool {
-        unimplemented!()
-    }
-
-    fn fetch_add_metadata(
-        _metadata_spec: &HeaderMetadataSpec,
-        _object: ObjectReference,
-        _val: usize,
-        _order: Ordering,
-    ) -> usize {
-        unimplemented!()
-    }
-
-    fn fetch_sub_metadata(
-        _metadata_spec: &HeaderMetadataSpec,
-        _object: ObjectReference,
-        _val: usize,
-        _order: Ordering,
-    ) -> usize {
-        unimplemented!()
-    }
 
     fn copy(
         _from: ObjectReference,

--- a/mmtk/src/scanning.rs
+++ b/mmtk/src/scanning.rs
@@ -4,8 +4,8 @@ use mmtk::vm::EdgeVisitor;
 use mmtk::vm::RootsWorkFactory;
 use mmtk::vm::Scanning;
 use mmtk::Mutator;
-use V8;
 use V8Edge;
+use V8;
 
 pub struct VMScanning {}
 


### PR DESCRIPTION
This PR updates mmtk-core to https://github.com/mmtk/mmtk-core/pull/647.