### PR TITLE
Update mmtk-core PR #650

### DIFF
--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -340,7 +340,7 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.14.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?branch=9473d7b4b92747d3c0998af3c41a6ef50c9c94e3"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=9473d7b4b92747d3c0998af3c41a6ef50c9c94e3#9473d7b4b92747d3c0998af3c41a6ef50c9c94e3"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -364,7 +364,7 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.14.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?branch=9473d7b4b92747d3c0998af3c41a6ef50c9c94e3"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=9473d7b4b92747d3c0998af3c41a6ef50c9c94e3#9473d7b4b92747d3c0998af3c41a6ef50c9c94e3"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -340,7 +340,7 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.14.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=76131c493be38e421f5fb157f9900f850584554f#76131c493be38e421f5fb157f9900f850584554f"
+source = "git+https://github.com/mmtk/mmtk-core.git?branch=barrier-refactor#180e18d8dc6b0332485298a04cf9334d89446ab3"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -363,7 +363,7 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.14.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=76131c493be38e421f5fb157f9900f850584554f#76131c493be38e421f5fb157f9900f850584554f"
+source = "git+https://github.com/mmtk/mmtk-core.git?branch=barrier-refactor#180e18d8dc6b0332485298a04cf9334d89446ab3"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -340,7 +340,7 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.14.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?branch=barrier-refactor#180e18d8dc6b0332485298a04cf9334d89446ab3"
+source = "git+https://github.com/mmtk/mmtk-core.git?branch=9473d7b4b92747d3c0998af3c41a6ef50c9c94e3"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -364,7 +364,7 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.14.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?branch=barrier-refactor#180e18d8dc6b0332485298a04cf9334d89446ab3"
+source = "git+https://github.com/mmtk/mmtk-core.git?branch=9473d7b4b92747d3c0998af3c41a6ef50c9c94e3"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -27,7 +27,7 @@ log = "*"
 # - change branch
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "76131c493be38e421f5fb157f9900f850584554f" }
+mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "180e18d8dc6b0332485298a04cf9334d89446ab3" }
 # Uncomment the following and fix the path to mmtk-core to build locally
 # mmtk = { path = "../repos/mmtk-core" }
 

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -27,7 +27,7 @@ log = "*"
 # - change branch
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "180e18d8dc6b0332485298a04cf9334d89446ab3" }
+mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "9473d7b4b92747d3c0998af3c41a6ef50c9c94e3" }
 # Uncomment the following and fix the path to mmtk-core to build locally
 # mmtk = { path = "../repos/mmtk-core" }
 

--- a/mmtk/src/lib.rs
+++ b/mmtk/src/lib.rs
@@ -61,7 +61,7 @@ impl VMBinding for V8 {
     type VMReferenceGlue = reference_glue::VMReferenceGlue;
 
     type VMEdge = V8Edge;
-    type VMMemorySlice = mmtk::vm::edge_shape::UnimplementedMemorySlice<JikesRVMEdge>;
+    type VMMemorySlice = mmtk::vm::edge_shape::UnimplementedMemorySlice<V8Edge>;
 
     const MAX_ALIGNMENT: usize = 32;
 }

--- a/mmtk/src/lib.rs
+++ b/mmtk/src/lib.rs
@@ -61,6 +61,7 @@ impl VMBinding for V8 {
     type VMReferenceGlue = reference_glue::VMReferenceGlue;
 
     type VMEdge = V8Edge;
+    type VMMemorySlice = mmtk::vm::edge_shape::UnimplementedMemorySlice<JikesRVMEdge>;
 
     const MAX_ALIGNMENT: usize = 32;
 }


### PR DESCRIPTION
This PR updates mmtk-core to https://github.com/mmtk/mmtk-core/pull/650.