### PR TITLE
Fixing CI scripts

### DIFF
--- a/.github/scripts/build-mmtk.sh
+++ b/.github/scripts/build-mmtk.sh
@@ -3,7 +3,7 @@ set -xe
 . $(dirname "$0")/common.sh
 
 # simply build mmtk-v8 with nogc
-rustup toolchain install $RUSTUP_TOOLCHAIN --target x86_64-unknown-linux-gnu --component clippy rustfmt
+rustup toolchain install $RUSTUP_TOOLCHAIN --target x86_64-unknown-linux-gnu --component clippy,rustfmt
 rustup override set $RUSTUP_TOOLCHAIN
 
 cd $THE_ROOT/mmtk && cargo build --features nogc

--- a/.github/scripts/ci-setup.sh
+++ b/.github/scripts/ci-setup.sh
@@ -2,5 +2,5 @@ set -xe
 
 . $(dirname "$0")/common.sh
 
-sudo apt-get install -y build-essential curl git python2 python3 pkg-config sudo vim clang
+sudo apt-get install -y build-essential curl git python3 pkg-config sudo vim clang
 sudo apt-get clean

--- a/.github/scripts/ci-setup.sh
+++ b/.github/scripts/ci-setup.sh
@@ -2,5 +2,5 @@ set -xe
 
 . $(dirname "$0")/common.sh
 
-sudo apt-get install -y build-essential curl git python3 pkg-config sudo vim clang
+sudo apt-get install -y build-essential curl git python2 python3 pkg-config sudo vim clang
 sudo apt-get clean

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,10 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       # Checkout repos and submodules
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup Environments
         run: ./.github/scripts/ci-setup.sh
 
@@ -34,20 +34,21 @@ jobs:
         run: ./.github/scripts/test-v8.sh
 
   msrv:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v2
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+      - uses: actions/checkout@v4
+
+      # Show the Rust toolchain we are actually using
+      - run: rustup show
+      - run: cargo --version
+
       - name: Install cargo-msrv
-        run: cargo install cargo-msrv
+        # The cargo-msrv tool sometimes requires a higher Rust version than our current rust-toolchain.
+        run: cargo +stable install cargo-msrv
       # Verify the MSRV defined in Cargo.toml
       - name: Verify MSRV
         run: cargo msrv --path mmtk verify
       # If the previous step fails, find MSRV
       - name: Find MSRV
         if: failure()
-        run: cargo msrv --path mmtk
+        run: cargo msrv --path mmtk find

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       # Checkout repos and submodules
       - uses: actions/checkout@v4
@@ -34,7 +34,7 @@ jobs:
         run: ./.github/scripts/test-v8.sh
 
   msrv:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
`rustup --component` should be comma-separated.

Removed the unmaintained `action-rs/toolchain` and assume the GitHub ubuntu image has the latest stable Rust toolchain installed.

Moved away from the ubuntu 20.04 which will be unsupported.